### PR TITLE
Update CAS from v1.1.0 to 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ branches:
   only:
     - master
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4
+  - 2.5
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
+project adheres to [Semantic Versioning](http://semver.org/)
+
+## 1.1.1 - 2016-09-19
+
+### Changed
+
+* Relax gemspec requirements, to add support for Rails 5.
+
+Note that the only tested versions of Ruby are now 2.1, 2.2, and 2.3 - older
+versions of Ruby should work, but are no longer officially supported.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # OmniAuth CAS Strategy [![Gem Version][version_badge]][version] [![Build Status][travis_status]][travis]
 
-> `omniauth-cas` is no longer maintained!
-> If you'd like to take over please open an issue!
-
 [version_badge]: https://badge.fury.io/rb/omniauth-cas.png
 [version]: http://badge.fury.io/rb/omniauth-cas
 [travis]: http://travis-ci.org/dlindahl/omniauth-cas

--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ Other configuration options:
 
     ```ruby
     provider :cas,
-             fetch_raw_info: lambda { |strategy, options, ticket, user_info|
-               ExternalService.get(user_info[:user]).attributes
-            }
+      fetch_raw_info: Proc.new { |strategy, opts, ticket, user_info, rawxml|
+        return {} if user_info.empty? || rawxml.nil? # Auth failed
+
+        extra_info = ExternalService.get(user_info[:user]).attributes
+        extra_info.merge!({'roles' => rawxml.xpath('//cas:roles').map(&:text)})
+        extra_info
+      }
     ```
 
 Configurable options for values returned by CAS:

--- a/lib/omniauth/cas/version.rb
+++ b/lib/omniauth/cas/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Cas
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -218,8 +218,11 @@ module OmniAuth
     private
 
       def fetch_raw_info(ticket)
-        ticket_user_info = validate_service_ticket(ticket).user_info
-        custom_user_info = options.fetch_raw_info.call(self, options, ticket, ticket_user_info)
+        validator = validate_service_ticket(ticket)
+        ticket_user_info = validator.user_info
+        ticket_success_body = validator.success_body
+        custom_user_info = options.fetch_raw_info.call(self,
+          options, ticket, ticket_user_info, ticket_success_body)
         self.raw_info = ticket_user_info.merge(custom_user_info)
       end
 

--- a/lib/omniauth/strategies/cas/saml_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/saml_ticket_validator.rb
@@ -9,6 +9,8 @@ module OmniAuth
 
         VALIDATION_REQUEST_HEADERS = { 'Accept' => '*/*' }
 
+        attr_reader :success_body
+
         # Build a validator from a +configuration+, a
         # +return_to+ URL, and a +ticket+.
         #

--- a/lib/omniauth/strategies/cas/service_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/service_ticket_validator.rb
@@ -8,6 +8,8 @@ module OmniAuth
       class ServiceTicketValidator
         VALIDATION_REQUEST_HEADERS = { 'Accept' => '*/*' }
 
+        attr_reader :success_body
+
         # Build a validator from a +configuration+, a
         # +return_to+ URL, and a +ticket+.
         #

--- a/spec/fixtures/cas_success.xml
+++ b/spec/fixtures/cas_success.xml
@@ -10,5 +10,8 @@
     <cas:image>/images/user.jpg</cas:image>
     <cas:phone>555-555-5555</cas:phone>
     <cas:hire_date>2004-07-13</cas:hire_date>
+    <cas:roles>senator</cas:roles>
+    <cas:roles>lobbyist</cas:roles>
+    <cas:roles>financier</cas:roles>
   </cas:authenticationSuccess>
 </cas:serviceResponse>

--- a/spec/fixtures/cas_success_jasig.xml
+++ b/spec/fixtures/cas_success_jasig.xml
@@ -11,6 +11,9 @@
       <cas:image>/images/user.jpg</cas:image>
       <cas:phone>555-555-5555</cas:phone>
       <cas:hire_date>2004-07-13</cas:hire_date>
+      <cas:roles>senator</cas:roles>
+      <cas:roles>lobbyist</cas:roles>
+      <cas:roles>financier</cas:roles>
     </cas:attributes>
   </cas:authenticationSuccess>
 </cas:serviceResponse>


### PR DESCRIPTION
I need the `fetch_raw_info` for read attributes types list (see https://github.com/dlindahl/omniauth-cas/issues/47).
This feature is available in the project dlindahl/omniauth-cas master. I am merging this in this branch.